### PR TITLE
'use strict' needs to be a string or else the app doesn't start up

### DIFF
--- a/MMM-OpenmapWeather.js
+++ b/MMM-OpenmapWeather.js
@@ -1,4 +1,4 @@
-use strict;
+'use strict';
 
 /* Magic Mirror
  * Module: MMM-OpenmapWeather


### PR DESCRIPTION
Without this being a string, the module doesn't start